### PR TITLE
Dont reboot on freq. change

### DIFF
--- a/commonregs.h
+++ b/commonregs.h
@@ -154,7 +154,7 @@ const void setSysState(uint8_t id, uint8_t *state)       \
  * 'id'       Register ID                                   \
  * 'channel'  New channel                                   \
  */                                                         \
-const void setFreqChannel(uint8_t id, uint8_t *channel)           \
+const void setFreqChannel(uint8_t id, uint8_t *channel)     \
 {                                                           \
   if (channel[0] != regFreqChannel.value[0])                \
   {                                                         \
@@ -164,8 +164,6 @@ const void setFreqChannel(uint8_t id, uint8_t *channel)           \
     packet.send();                                          \
     /* Update register value */                             \
     panstamp.radio.setChannel(channel[0]);                  \
-    /* Restart device */                                    \
-    panstamp.reset();                                       \
   }                                                         \
 }                                                           \
                                                             \


### PR DESCRIPTION
@dberenguer, we discovered this issue while developing a SWAP device. By rebooting in the update callback, you prevent the write to nvram, which happens after the callback.

Remove reboot that prevents the data from being saved to nvram after the callback. Also fix an alignment.
